### PR TITLE
Unmute sources with no active port

### DIFF
--- a/src/pulseaudio/mod.rs
+++ b/src/pulseaudio/mod.rs
@@ -99,8 +99,11 @@ impl Controller {
                             };
                             trace!("device source: {:?}", src.description);
                             if toggle {
-                                ctx_volume_controller
-                                    .set_source_mute_by_index(src.index, mute, None);
+                                ctx_volume_controller.set_source_mute_by_index(
+                                    src.index,
+                                    src.active_port.is_some() && mute,
+                                    None,
+                                );
                             }
                         }
                     });


### PR DESCRIPTION
mSBC sources remain "muted" even when they are unmuted via pulseaudio, if this device's source is muted in A2DP mode. In A2DP the source has no active port, so it is used as a check, that such source must always be unmuted.